### PR TITLE
Fixed `pip` location for Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: julia
 os:
     - linux
     - osx
+    - windows
 julia:
     - 1.3
     - nightly

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,7 @@ run(`julia configure_pycall.jl`)
 
 using PyCall
 
-const PIP = joinpath(split(PyCall.PYTHONHOME, ":")[end], "bin/pip")
+include("set_pip.jl")
 
 function pipinstall(pkg)
     try

--- a/deps/configure_pycall.jl
+++ b/deps/configure_pycall.jl
@@ -1,8 +1,8 @@
 import PyCall, Pkg
 
-pip = joinpath(split(PyCall.PYTHONHOME, ":")[end], "bin/pip")
+include("set_pip.jl")
 
-if !isfile(pip)
+if !isfile(PIP)
     println("`pip` is not available in the current PyCall.jl")
     println("Configuring PyCall.jl to use Conda.jl")
     ENV["PYTHON"] = ""

--- a/deps/set_pip.jl
+++ b/deps/set_pip.jl
@@ -1,0 +1,5 @@
+if Sys.iswindows()
+    const PIP = joinpath(PyCall.PYTHONHOME, "Scripts", "pip.exe")
+else
+    const PIP = joinpath(split(PyCall.PYTHONHOME, ":")[end], "bin/pip")
+end


### PR DESCRIPTION
Due to errors from here (https://github.com/sisl/AutonomousRiskFramework.jl/runs/6429671685?check_suite_focus=true#step:5:642) I added support for finding `pip.exe` on Windows.

I also added Windows to the Travis CI config.

Could you update the version to `0.5.1` and register this so my other builds (above) can be resolved? Thank you very much.